### PR TITLE
formatCurrencyAmount bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
-## next
+## <next>
+* Bug fix in `formatCurrencyAmount` function
+
+## 2.1.1
 * Enhanced decimal/thousand separator handling in `formatCurrencyAmount` function
 
 ## 2.1.0

--- a/src/format-utils/format-utils.js
+++ b/src/format-utils/format-utils.js
@@ -117,10 +117,9 @@ export const formatNumber = (value, options = {}) => {
 export const formatCurrencyAmount = (amount, options = {}) => {
   let amountStr = String(amount).replace(/\s/g, '');
 
-  // Replaces all commas with dots, if comma isn't used as a thousand separator
-  if (options.thousandSeparator !== ',') {
-    amountStr = amountStr.replace(',', '.');
-  }
+  // Strips all commas OR replaces all commas with dots, if comma isn't used as a thousand separator
+  const replaceValue = (options.thousandSeparator !== ',') ? '.' : '';
+  amountStr = amountStr.replace(/,/g, replaceValue);
 
   const decimals = options.decimals === undefined
     ? getCurrencyDecimals(options.currency)


### PR DESCRIPTION
Commas are now being stripped from amount before calling `formatNumber`

* Commas are replaced with dot, if `thousandSeparator` does not equal `,`
* Commas are replaced with white space, if `thousandSeparator` equals `,`