### PR TITLE
Bug fix in `formatCurrencyAmount` function: if region is for example …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Bug fix in `formatCurrencyAmount` function: if region is for example Dansk or German and thousand separator is dot, first instance of thousand separator in the input is twisted to decimal separator.
 
 ## 2.2.3
 * Hard code some currency decimal counts that were wrong in Chrome

--- a/src/format-utils/format-utils.js
+++ b/src/format-utils/format-utils.js
@@ -130,9 +130,15 @@ export const formatNumber = (value, options = {}) => {
 export const formatCurrencyAmount = (amount, options = {}) => {
   let amountStr = String(amount).replace(/\s/g, '');
 
-  // Strips all commas OR replaces all commas with dots, if comma isn't used as a thousand separator
-  const replaceValue = (options.thousandSeparator !== ',') ? '.' : '';
-  amountStr = amountStr.replace(/,/g, replaceValue);
+  // Strips all thousand separator
+  if (options.thousandSeparator) {
+    amountStr = amountStr.replace(new RegExp(`\\${options.thousandSeparator}`, 'g'), '');
+  }
+  // before number convertion decimal separator is replaced with proper one
+  if (options.decimalSeparator !== '.') {
+    amountStr = amountStr.replace(new RegExp(`\\${options.decimalSeparator}`, 'g'), '.');
+  }
+
   const { multiplier } = options;
   const amountFloat = multiplier ? multiplier * parseFloat(amountStr) : parseFloat(amountStr);
 

--- a/test/format-utils/format-utils.spec.js
+++ b/test/format-utils/format-utils.spec.js
@@ -28,6 +28,42 @@ describe('Format utils', function describe() {
       decimalSeparator: '.',
       multiplier: 0.001,
     })).to.eql('-1,234.57');
+    expect(FormatUtils.formatCurrencyAmount('-1.000', {
+      currency: 'EUR',
+      thousandSeparator: '.',
+      decimalSeparator: ',',
+      multiplier: 1,
+    })).to.eql('-1.000,00');
+    expect(FormatUtils.formatCurrencyAmount('-9.999,989', {
+      currency: 'EUR',
+      thousandSeparator: '.',
+      decimalSeparator: ',',
+      multiplier: 1,
+    })).to.eql('-9.999,99');
+    expect(FormatUtils.formatCurrencyAmount('-2.000,00', {
+      currency: 'EUR',
+      thousandSeparator: '.',
+      decimalSeparator: ',',
+      multiplier: 1,
+    })).to.eql('-2.000,00');
+    expect(FormatUtils.formatCurrencyAmount('1.234.567,89', {
+      currency: 'EUR',
+      thousandSeparator: '.',
+      decimalSeparator: ',',
+      multiplier: 1,
+    })).to.eql('1.234.567,89');
+    expect(FormatUtils.formatCurrencyAmount('1.234.567,89', {
+      currency: 'EUR',
+      thousandSeparator: '.',
+      decimalSeparator: ',',
+      multiplier: 0.001,
+    })).to.eql('1.234,57');
+    expect(FormatUtils.formatCurrencyAmount('1.234.567,89', {
+      currency: 'EUR',
+      thousandSeparator: '.',
+      decimalSeparator: ',',
+      multiplier: 0.000001,
+    })).to.eql('1,23');
     expect(FormatUtils.formatDate('2017-01-01T00:00:00.000Z', 'DD.MM.YYYY')).to.eql('01.01.2017');
     const year = new Date().getFullYear();
     expect(FormatUtils.formatDateToISO('01.01', 'DD.MM.YYYY')).to.eql(`${year}-01-01T00:00:00.000Z`);


### PR DESCRIPTION
…Dansk or German and thousand separator is dot, first instance of thousand separator in the input is twisted to decimal separator